### PR TITLE
Add ninja to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: System :: Networking',
     ]),
-    setup_requires=['cffi', 'pytest-runner',],
+    setup_requires=['cffi', 'pytest-runner', 'ninja'],
     install_requires=['cffi', 'sniffio'],
     cffi_modules=['build_pynng.py:ffibuilder'],
     tests_require=[


### PR DESCRIPTION
Pip runs the package build in an additional isolated venv during install which needs the ninja package to build nng.