### PR TITLE
Use a environment variable to select static or shared nng library

### DIFF
--- a/build_pynng.py
+++ b/build_pynng.py
@@ -37,9 +37,6 @@ else:
     incdirs = ["nng/include"]
     objects = [
         "./nng/build/libnng.a",
-        "./mbedtls/prefix/lib/libmbedtls.a",
-        "./mbedtls/prefix/lib/libmbedx509.a",
-        "./mbedtls/prefix/lib/libmbedcrypto.a",
     ]
     libraries = ["pthread"]
     machine = os.uname().machine

--- a/nng_api.h
+++ b/nng_api.h
@@ -15,6 +15,7 @@ typedef struct nng_socket_s {
  uint32_t id;
 } nng_socket;
 typedef int32_t nng_duration;
+typedef uint64_t nng_time;
 typedef struct nng_msg nng_msg;
 typedef struct nng_stat nng_stat;
 typedef struct nng_aio nng_aio;
@@ -80,7 +81,7 @@ enum nng_sockaddr_family {
  NNG_AF_ABSTRACT = 6
 };
 typedef struct nng_iov {
- void * iov_buf;
+ void *iov_buf;
  size_t iov_len;
 } nng_iov;
 extern void nng_fini(void);
@@ -215,6 +216,7 @@ extern void *nng_aio_get_input(nng_aio *, unsigned);
 extern int nng_aio_set_output(nng_aio *, unsigned, void *);
 extern void *nng_aio_get_output(nng_aio *, unsigned);
 extern void nng_aio_set_timeout(nng_aio *, nng_duration);
+extern void nng_aio_set_expire(nng_aio *, nng_time);
 extern int nng_aio_set_iov(nng_aio *, unsigned, const nng_iov *);
 extern bool nng_aio_begin(nng_aio *);
 extern void nng_aio_finish(nng_aio *, int);
@@ -226,9 +228,9 @@ extern void nng_msg_free(nng_msg *);
 extern int nng_msg_realloc(nng_msg *, size_t);
 extern int nng_msg_reserve(nng_msg *, size_t);
 extern size_t nng_msg_capacity(nng_msg *);
-extern void * nng_msg_header(nng_msg *);
+extern void *nng_msg_header(nng_msg *);
 extern size_t nng_msg_header_len(const nng_msg *);
-extern void * nng_msg_body(nng_msg *);
+extern void *nng_msg_body(nng_msg *);
 extern size_t nng_msg_len(const nng_msg *);
 extern int nng_msg_append(nng_msg *, const void *, size_t);
 extern int nng_msg_insert(nng_msg *, const void *, size_t);
@@ -534,8 +536,8 @@ const char *nng_tls_engine_name(void);
 const char *nng_tls_engine_description(void);
 bool nng_tls_engine_fips_mode(void);
 int nng_tls_register(void);
-#define NNG_FLAG_ALLOC 1u // Recv to allocate receive buffer
+#define NNG_FLAG_ALLOC 1u    // Recv to allocate receive buffer
 #define NNG_FLAG_NONBLOCK 2u // Non-blocking operations
 #define NNG_MAJOR_VERSION 1
-#define NNG_MINOR_VERSION 6
-#define NNG_PATCH_VERSION 0
+#define NNG_MINOR_VERSION 7
+#define NNG_PATCH_VERSION 3

--- a/pynng/_version.py
+++ b/pynng/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.0+dev"
+__version__ = "0.8.99+dev"

--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -34,9 +34,15 @@ Surveyor0 Respondent0
 #     during a callback to _nng_pipe_cb
 #   * Cleanup background queue threads used by NNG
 
+# NOTE: enabling this can lead to nng panic / crash on python runtime shutdown. Depending on when the atexit function
+# is called and objects garbage are collected, it might be possible that nng_fini is already called, but we are is
+# still calling the nng lib (e.g. nni_aio_free by AIOHelper.__del__).
+
+nng_fini_at_exit = False
 
 def _pynng_atexit():
-    lib.nng_fini()
+    if nng_fini_at_exit:
+        lib.nng_fini()
 
 
 atexit.register(_pynng_atexit)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [build_nng]
 repo=https://github.com/nanomsg/nng
-rev=v1.6.0
+rev=v1.7.3
 
 [build_mbedtls]
 repo=https://github.com/ARMmbed/mbedtls.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [build_nng]
-repo=https://github.com/nanomsg/nng
-rev=v1.7.3
+repo=https://github.com/husqvarnagroup/nng
+rev=071be4f0b602119032cfd8a2de2e245d79551e0a
 
 [build_mbedtls]
 repo=https://github.com/ARMmbed/mbedtls.git

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class BuilderBase(Command):
         """Clone nng and build it with cmake, with TLS enabled."""
         if not os.path.exists(self.git_dir):
             check_call("git clone {}".format(self.repo), shell=True)
-            check_call("git checkout {}".format(self.rev), shell=True, cwd=self.git_dir)
+            check_call("git checkout -f {}".format(self.rev), shell=True, cwd=self.git_dir)
         if not os.path.exists(self.build_dir):
             os.mkdir(self.build_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -80,12 +80,13 @@ class BuildNng(BuilderBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.git_dir = "nng"
+        # Disable linking with mbedtls for this build. NNG 1.7.3 does not properly
+        # build with a custom mbedtls build directory. We do not use TLS anyway.
         self.cmake_extra_args = [
-            "-DNNG_ENABLE_TLS=ON",
+            "-DNNG_ENABLE_TLS=OFF",
             "-DNNG_TESTS=OFF",
             "-DNNG_TOOLS=OFF",
             "-DCMAKE_BUILD_TYPE=Release",
-            "-DMBEDTLS_ROOT_DIR={}/mbedtls/prefix/".format(THIS_DIR),
         ]
 
     def finalize_build(self):
@@ -157,7 +158,6 @@ class BuildBuild(build_ext):
         Running...
         """
         if not PYNNG_USE_SHARED_LIBS:
-            self.run_command("build_mbedtls")
             self.run_command("build_nng")
 
         build_ext.run(self)  # proceed with "normal" build steps
@@ -168,7 +168,6 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     cmdclass={
-        "build_mbedtls": BuildMbedTls,
         "build_nng": BuildNng,
         "build_ext": BuildBuild,
     },

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ if platform.machine() == "i686" and platform.system() == "Linux":
     os.environ["CFLAGS"] = "-mpclmul -msse2 -maes"
 from setuptools import Command, setup, find_packages
 from setuptools.command.build_ext import build_ext
-from distutils.command.build import build as dbuild
 
 WINDOWS = sys.platform == "win32"
 
@@ -145,10 +144,6 @@ class BuildBuild(build_ext):
     """
     Custom build command
     """
-
-    # dbuild.user_options += [
-    #    ('build-deps', None, 'build nng and mbedtls before building the module')
-    # ]
     build_ext.user_options += [
         ("build-deps", None, "build nng and mbedtls before building the module")
     ]
@@ -158,7 +153,6 @@ class BuildBuild(build_ext):
         Set default values for options
         Each user option must be listed here with their default value.
         """
-        # dbuild.initialize_options(self)
         build_ext.initialize_options(self)
         self.build_deps = "yes"
 
@@ -170,7 +164,6 @@ class BuildBuild(build_ext):
             self.run_command("build_mbedtls")
             self.run_command("build_nng")
 
-        # dbuild.run(self) # proceed with "normal" build steps
         build_ext.run(self)  # proceed with "normal" build steps
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools.command.build_ext import build_ext
 WINDOWS = sys.platform == "win32"
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-
+PYNNG_USE_SHARED_LIBS = True if os.environ.get("PYNNG_USE_SHARED_LIBS", None) in ("YES", "yes") else False
 
 def maybe_copy(src, dst):
     os.makedirs(os.path.dirname(dst), exist_ok=True)
@@ -156,8 +156,9 @@ class BuildBuild(build_ext):
         """
         Running...
         """
-        self.run_command("build_mbedtls")
-        self.run_command("build_nng")
+        if not PYNNG_USE_SHARED_LIBS:
+            self.run_command("build_mbedtls")
+            self.run_command("build_nng")
 
         build_ext.run(self)  # proceed with "normal" build steps
 

--- a/setup.py
+++ b/setup.py
@@ -144,9 +144,6 @@ class BuildBuild(build_ext):
     """
     Custom build command
     """
-    build_ext.user_options += [
-        ("build-deps", None, "build nng and mbedtls before building the module")
-    ]
 
     def initialize_options(self):
         """
@@ -154,15 +151,13 @@ class BuildBuild(build_ext):
         Each user option must be listed here with their default value.
         """
         build_ext.initialize_options(self)
-        self.build_deps = "yes"
 
     def run(self):
         """
         Running...
         """
-        if self.build_deps:
-            self.run_command("build_mbedtls")
-            self.run_command("build_nng")
+        self.run_command("build_mbedtls")
+        self.run_command("build_nng")
 
         build_ext.run(self)  # proceed with "normal" build steps
 


### PR DESCRIPTION
### static
Use
```
pip install git+https://github.com/husqvarnagroup/pynng@gardena/ml/option-to-use-shared-library
```
or with poetry
```
pynng = { git = "https://github.com/husqvarnagroup/pynng.git", branch = "gardena/ml/option-to-use-shared-library", optional = true }
```
to install pynng with a static library build during python package install.

### shared
Run 
```
PYNNG_USE_SHARED_LIB=YES pip install git+https://github.com/husqvarnagroup/pynng@gardena/ml/option-to-use-shared-library
```
to build with a pre-installed shared library. This also works with Yocto.