### PR TITLE
[sg temphack] depend on ninja

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ requires = [
     "cmake",
     "build",
     "wheel",
+    "ninja",
 ]
 
 [tool.cibuildwheel]


### PR DESCRIPTION
Runtime detection of ninja during build time is not done correctly, thus require ninja to circumvent this problem.